### PR TITLE
migrated sesheta approver bot from core/bots

### DIFF
--- a/approver.py
+++ b/approver.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Sesheta
+# Copyright(C) 2018,2019
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""This is Sesheta -approver bot, she is a Cyborg Team Member of https://github.com/Thoth-Station/."""
+
+import os
+import logging
+
+import daiquiri
+import sesheta
+
+from github import Github
+from github import UnknownObjectException
+
+from sesheta.common import CICD_CONTEXT_ID, get_labels, commit_was_successful_tested, init_github_interface
+
+
+DEBUG = bool(os.getenv("DEBUG", False))
+SESHETA_GITHUB_ACCESS_TOKEN = os.getenv("SESHETA_GITHUB_ACCESS_TOKEN", None)
+
+daiquiri.setup(level=logging.INFO)
+logger = daiquiri.getLogger("approver")
+
+if DEBUG:
+    logger.setLevel(level=logging.DEBUG)
+else:
+    logger.setLevel(level=logging.INFO)
+
+logger.info(f"Version v{sesheta.__version__}")
+
+
+if __name__ == "__main__":
+    if not SESHETA_GITHUB_ACCESS_TOKEN:
+        logger.error("Github Token not provided via environment variable SESHETA_GITHUB_ACCESS_TOKEN")
+        exit(-1)
+
+    github, org, GITHUB_ORGANIZATION, GITHUB_REPOSITORIES, DEFAULT_LABELS = init_github_interface(
+        SESHETA_GITHUB_ACCESS_TOKEN, "etc/config.json"
+    )
+
+    logger.info(f"Hi, I'm {github.get_user().name}, and I'm fully operational now!")
+    logger.debug("... and I am running in DEBUG mode!")
+
+    for _repo in GITHUB_REPOSITORIES:
+        logger.info(f"checking Repository '{org.login}/{_repo}' for Pull Requests that could be 'approved'")
+
+        repo = org.get_repo(_repo)
+
+        for pr in repo.get_pulls(state="open"):
+            logger.debug(pr)
+
+            labels = get_labels(pr)
+
+            if pr.title.startswith("WIP") or pr.title.startswith("[WIP]") or ("work-in-progress" in labels):
+                logger.info(f"'{pr.title}' is not mergeable, it's work-in-progress!")
+
+                if "work-in-progress" not in labels:
+                    pr.as_issue().add_to_labels("work-in-progress")
+
+                continue
+
+            if not pr.mergeable:
+                logger.info(f"'{pr.title}' is not mergeable, it needs rebase!")
+
+                pr.as_issue().add_to_labels("needs-rebase")
+                continue
+
+            if pr.mergeable and ("needs-rebase" in labels):
+                logger.info(f"'{pr.title}' is mergeable, removieng 'needs-rebase' label")
+
+                pr.as_issue().remove_from_labels("needs-rebase")
+
+            # if all commits of this PR are CI'd positive, we might approve the PR
+            commits = pr.get_commits()
+            maybe_approve = False
+
+            for commit in commits:
+                statuses = commit.get_statuses()
+
+                if commit_was_successful_tested(commit, statuses):
+                    logger.debug(f"commit '{commit}' was successfully tested by {CICD_CONTEXT_ID}")
+
+                    maybe_approve = True
+
+            if maybe_approve:
+                logger.info(f"I are going to approve Pull Request '{pr.title}'")
+                pr.as_issue().add_to_labels("approved")
+
+            else:
+                logger.info(f"Pull Request '{pr.title}' could not be approved due to failed CI")

--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -132,3 +132,51 @@ objects:
               restartPolicy: Never
       schedule: '29 14 * * 1,3,5'
       suspend: false
+
+  - kind: CronJob
+    apiVersion: batch/v1beta1
+    metadata:
+      name: sesheta-approver
+      labels:
+        app: sesheta
+        component: approver
+    spec:
+      schedule: '*/60 * * * *'
+      suspend: false
+      concurrencyPolicy: Forbid
+      successfulJobsHistoryLimit: 2
+      failedJobsHistoryLimit: 2
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+                - image: sesheta:latest
+                  name: sesheta-approver
+                  env:
+                    - name: APP_FILE
+                      value: approver.py
+                    - name: SESHETA_GITHUB_ACCESS_TOKEN
+                      valueFrom:
+                        secretKeyRef:
+                          key: github-oauth-token
+                          name: sesheta-secret
+                  resources:
+                    requests:
+                      memory: "32Mi"
+                      cpu: "100m"
+                    limits:
+                      memory: "128Mi"
+                      cpu: "250m"
+                  volumeMounts:
+                    - mountPath: /opt/app-root/src/etc
+                      name: sesheta-bot-config
+                      readOnly: true
+              volumes:
+                - name: sesheta-bot-config
+                  configMap:
+                    items:
+                      - key: sesheta-bot-config-json
+                        path: config.json
+                    name: sesheta-bot
+              restartPolicy: Never

--- a/sesheta/common.py
+++ b/sesheta/common.py
@@ -33,7 +33,7 @@ _LOGGER = daiquiri.getLogger(__name__)
 
 
 CICD_CONTEXT_ID = "continuous-integration/jenkins/pr-merge"
-DO_NOT_MERGE_LABELS = ["do-not-merge", "work-in-progress", "do-not-merge/work-in-progress" "do-not-merge/hold"]
+DO_NOT_MERGE_LABELS = ["do-not-merge", "work-in-progress", "do-not-merge/work-in-progress", "do-not-merge/hold"]
 
 
 def init_github_interface(
@@ -92,3 +92,19 @@ def get_labels(pr) -> list:  # pragma: no cover
         _LOGGER.error(e)
 
     return labels
+
+
+def commit_was_successful_tested(commit, statuses):
+    """Ensure CI test on commit was successful."""
+    latest_status_id = 0
+    rc = False
+
+    for status in statuses:
+        if status.context == CICD_CONTEXT_ID:
+            _LOGGER.debug(f"{commit} {status}")
+
+            if latest_status_id < status.id:
+                if status.state == "success":
+                    rc = True
+
+    return rc


### PR DESCRIPTION
PR contains **sesheta-approver** bot application.
The bot adds an appropriate label to GitHub pr and issue in the repos.
- Migrated approver.py from thoth-station/core/bots and required function to sesheta/common.py
- Add required cronjob for the bot.