### PR TITLE
fixes for using config json from configmap and deployment templates

### DIFF
--- a/check_if_labels_present.py
+++ b/check_if_labels_present.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         exit(-1)
 
     github, org, GITHUB_ORGANIZATION, GITHUB_REPOSITORIES, DEFAULT_LABELS = init_github_interface(
-        SESHETA_GITHUB_ACCESS_TOKEN, "config-aicoe.json"
+        SESHETA_GITHUB_ACCESS_TOKEN, "etc/config.json"
     )
 
     logger.info(f"Hi, I'm {github.get_user().name}, and I'm fully operational now!")

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -62,7 +62,7 @@ parameters:
     displayName: Thoth sesheta git repository
     required: true
     name: GITHUB_URL
-    value: 'https://github.com/thoth-station/sesheta'
+    value: 'https://github.com/AICoE/sesheta'
 
   - description: Git reference for Thoth's sesheta
     displayName: Thoth sesheta git reference

--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -22,33 +22,33 @@ metadata:
 
 objects:
   - kind: CronJob
-    apiVersion: batch/v2alpha1
+    apiVersion: batch/v1beta1
     metadata:
       name: sesheta-label-checker
       labels:
         app: sesheta
         component: label-checker
     spec:
-      schedule: '21 4 * * *'
-      suspend: true
+      schedule: '@daily'
+      suspend: false
       concurrencyPolicy: Forbid
       successfulJobsHistoryLimit: 2
-      failedJobsHistoryLimit: 4
+      failedJobsHistoryLimit: 2
       jobTemplate:
         spec:
           template:
             spec:
               containers:
-                - image: sesheta
-                  name: sesheta
+                - image: sesheta:latest
+                  name: sesheta-label-checker
                   env:
                     - name: APP_FILE
                       value: check_if_labels_present.py
                     - name: SESHETA_GITHUB_ACCESS_TOKEN
                       valueFrom:
                         secretKeyRef:
-                          key: sesheta-github-access-token
-                          name: github-access-tokens
+                          key: github-oauth-token
+                          name: sesheta-secret
                   resources:
                     requests:
                       memory: "32Mi"
@@ -56,6 +56,17 @@ objects:
                     limits:
                       memory: "128Mi"
                       cpu: "250m"
+                  volumeMounts:
+                    - mountPath: /opt/app-root/src/etc
+                      name: sesheta-bot-config
+                      readOnly: true
+              volumes:
+                - name: sesheta-bot-config
+                  configMap:
+                    items:
+                      - key: sesheta-bot-config-json
+                        path: config.json
+                    name: sesheta-bot
               restartPolicy: Never
 
   - kind: CronJob
@@ -67,7 +78,7 @@ objects:
         component: scrum-standup
     spec:
       concurrencyPolicy: Forbid
-      successfulJobsHistoryLimit: 1
+      successfulJobsHistoryLimit: 2
       failedJobsHistoryLimit: 2
       jobTemplate:
         spec:
@@ -79,8 +90,26 @@ objects:
                   env:
                     - name: APP_FILE
                       value: scrum_standup.py
+                    - name: SESHETA_VERBOSE
+                      valueFrom:
+                        configMapKeyRef:
+                          key: sesheta-verbose
+                          name: sesheta-configmap
                     - name: SESHETA_SCRUM_MESSAGE
-                      value: "the scrum is due in one minute... dial in to https://bluejeans.com/5618223545"
+                      valueFrom:
+                        configMapKeyRef:
+                          key: scrum-message
+                          name: sesheta-configmap
+                    - name: SESHETA_SCRUM_SPACE
+                      valueFrom:
+                        configMapKeyRef:
+                          key: scrum-space
+                          name: sesheta-configmap
+                    - name: SESHETA_SCRUM_URL
+                      valueFrom:
+                        configMapKeyRef:
+                          key: scrum-url
+                          name: sesheta-configmap
                   resources:
                     limits:
                       cpu: 250m
@@ -101,16 +130,5 @@ objects:
                         path: credentials.json
                     secretName: sesheta-pubsub-consumer
               restartPolicy: Never
-      schedule: 29 14 * * 1,3,5
+      schedule: '29 14 * * 1,3,5'
       suspend: false
-
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      labels:
-        app: sesheta
-      name: sesheta
-    spec:
-      name: latest
-      lookupPolicy:
-        local: true

--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -79,16 +79,16 @@ objects:
                     secretKeyRef:
                       name: sesheta-secret
                       key: github-webhook-secret
-                - name: SESHETA_MATTERMOST_ENDPOINT_URL
-                  valueFrom:
-                    secretKeyRef:
-                      name: sesheta-secret
-                      key: mattermost-endpoint-url
                 - name: SESHETA_GOOGLE_CHAT_ENDPOINT_URL
                   valueFrom:
                     secretKeyRef:
                       name: sesheta-secret
                       key: google-chat-endpoint-url
+                - name: SESHETA_GITHUB_ACCESS_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: github-oauth-token
+                      name: sesheta-secret
               ports:
                 - containerPort: 8080
                   protocol: TCP
@@ -99,6 +99,17 @@ objects:
                 limits:
                   memory: "256Mi"
                   cpu: "500m"
+              volumeMounts:
+                - name: sesheta-pubsub-consumer
+                  mountPath: /opt/app-root/etc/gcloud
+                  readOnly: true
+          volumes:
+            - name: sesheta-pubsub-consumer
+              secret:
+                secretName: sesheta-pubsub-consumer
+                items:
+                  - key: sesheta-chatbot-968e13a86991.json
+                    path: sesheta-chatbot-968e13a86991.json
       test: false
       triggers:
         - type: ConfigChange


### PR DESCRIPTION
PR fixes :
- use of config.json through openshift config map rather than internal files of application.
- updated templates as per openshift 3.11 and higher requirement.
- add required parameters and attributes to the template required for bots functionality.