### PR TITLE
wrong switch between secret and token

### DIFF
--- a/sesheta/webhook_processors/github_reviews.py
+++ b/sesheta/webhook_processors/github_reviews.py
@@ -58,4 +58,5 @@ def process_github_pull_request_review_requested(pullrequest: dict) -> None:
 def process_github_pull_request_review_submitted(pullrequest: dict, review: dict) -> None:
     """Will handle with care."""
     if review["state"].startswith("approved"):
-        _LOGGER.info("TODO set label 'approved' for {pullrequest['html_url']}")
+        _LOGGER.info("Set label 'approved' for {pullrequest['html_url']}")
+        add_labels(pullrequest["_links"]["issue"]["href"], ["approved"])

--- a/sesheta/webhooks.py
+++ b/sesheta/webhooks.py
@@ -48,6 +48,7 @@ _LOGGER = daiquiri.getLogger(__name__)
 _RELATED_REGEXP = r"\w+:\ \#([0-9]+)"
 _DRY_RUN = os.environ.get("SESHETA_DRY_RUN", False)
 _SESHETA_GITHUB_ACCESS_TOKEN = os.getenv("SESHETA_GITHUB_ACCESS_TOKEN", None)
+_SESHETA_GITHUB_WEBHOOK_SECRET = os.getenv("SESHETA_GITHUB_WEBHOOK_SECRET", None)
 _GIT_API_REQUEST_HEADERS = {"Authorization": "token %s" % _SESHETA_GITHUB_ACCESS_TOKEN}
 
 
@@ -242,7 +243,7 @@ def handle_github_webhook():  # pragma: no cover
     signature = request.headers.get("X-Hub-Signature")
     sha, signature = signature.split("=")
 
-    secret = str.encode(_SESHETA_GITHUB_ACCESS_TOKEN)
+    secret = str.encode(_SESHETA_GITHUB_WEBHOOK_SECRET)
 
     hashhex = hmac.new(secret, request.data, digestmod="sha1").hexdigest()
 


### PR DESCRIPTION
Found a minor error,
- The webhook secret was switched with access token; fixed it.

Label add for `approved`:
Might fix the #14 